### PR TITLE
Bug Fixed

### DIFF
--- a/taxii2-threat-intel-feed/info.json
+++ b/taxii2-threat-intel-feed/info.json
@@ -219,7 +219,7 @@
           "description": "Specify the ID of the collection whose general information, such as ID, Title, Description, Can Read, Can Write, and Media Types you want to retrieve from TAXII Threat Intelligence Feed."
         },
         {
-          "title": "Created After",
+          "title": "Added After",
           "name": "added_after",
           "visible": true,
           "required": false,
@@ -314,7 +314,7 @@
           "description": "Specify the ID of the collection whose general information, such as ID, Title, Description, Can Read, Can Write, and Media Types you want to retrieve from TAXII Threat Intelligence Feed."
         },
         {
-          "title": "Created After",
+          "title": "Added After",
           "name": "added_after",
           "visible": true,
           "required": false,

--- a/taxii2-threat-intel-feed/release_notes.md
+++ b/taxii2-threat-intel-feed/release_notes.md
@@ -4,3 +4,5 @@
 - The issue has been resolved in the connector code to support all client-server URLs.
 - Added the following actions and playbooks:
     - `Get Objects`
+- Updated the parameter name `Created After` to `Added After` in the following operations:
+    - `Fetch Indicators`


### PR DESCRIPTION
#### PMDB: 38264

#### Mantis:

- 1194910: Action Parameter `Created After` Should Be Renamed To `Added After` As Per The TAXII 2.1 Protocol

#### Descriptions:

- Updated the parameter name `Created After` to `Added After` in the following operations:
    - `Fetch Indicators`
    - 'Get Objects'