### PR TITLE
Mantis#1290644 -> New Enchancement

### DIFF
--- a/taxii2-threat-intel-feed/connector.py
+++ b/taxii2-threat-intel-feed/connector.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2025 Fortinet Inc
+Copyright (c) 2026 Fortinet Inc
 Copyright end
 """
 
@@ -16,7 +16,6 @@ class TAXIIFeedCon(Connector):
         logger.info('In execute() Operation: {}'.format(operation))
         try:
             operation = operations.get(operation)
-            # todo let call connector take it from _info
             # now was ingesting it from integration separately
             # changes for fcp/tip specific so it dsnt break on fsr
             if 'connector_name' in kwargs:

--- a/taxii2-threat-intel-feed/constants.py
+++ b/taxii2-threat-intel-feed/constants.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2025 Fortinet Inc
+Copyright (c) 2026 Fortinet Inc
 Copyright end
 """
 

--- a/taxii2-threat-intel-feed/info.json
+++ b/taxii2-threat-intel-feed/info.json
@@ -3,6 +3,7 @@
   "label": "TAXII Threat Intel Feed",
   "description": "TAXII Threat Intel Feed connector acts as a STIX-compliant TAXII client. It connects to user-specified TAXII servers (TAXII v2.1), discovers and enumerates collections via API Root, and retrieves STIX-formatted threat intelligence objects—such as Indicators, Malware, Campaigns—on schedule using Data Ingestion or on demand. <br/><br/>This connector has a dependency on the <a href=\"/content-hub/all-content/?contentType=solutionpack&amp;tag=ThreatIntelManagement\" target=\"_blank\" rel=\"noopener\">Threat Intel Management Solution Pack</a>. Install the Solution Pack before enabling ingestion of Threat Feeds from this source.",
   "publisher": "Fortinet",
+  "contributor": "Dylan Spille",
   "cs_approved": true,
   "cs_compatible": true,
   "version": "2.0.0",

--- a/taxii2-threat-intel-feed/info.json
+++ b/taxii2-threat-intel-feed/info.json
@@ -5,7 +5,7 @@
   "publisher": "Fortinet",
   "cs_approved": true,
   "cs_compatible": true,
-  "version": "1.2.1",
+  "version": "2.0.0",
   "category": "Threat Intelligence",
   "icon_small_name": "small.png",
   "icon_large_name": "large.png",
@@ -17,7 +17,7 @@
     "ThreatIntel",
     "ThreatFeedsIngestion"
   ],
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.2.1/taxii-threat-intel-feed/1756118021/taxii-threat-intel-feed-v1-2-1",
+  "help_online": "",
   "ingestion_config_schema": [
     {
       "title": "Ingestion Begin From",
@@ -118,34 +118,94 @@
         "tooltip": "The server URL of the TAXII Threat Intelligence Feed server to connect and retrieve data. If the complete feed collections URL is https://threatfeed.example.com/taxii/root/collections/, provide only https://threatfeed.example.com/taxii/root/ as API Root."
       },
       {
-        "title": "Username/API Key",
+        "title": "Authentication Type",
+        "name": "auth_type",
+        "type": "select",
         "required": true,
         "editable": true,
         "visible": true,
-        "type": "text",
-        "name": "username",
-        "description": "The Username/API Key that is configured for your account to access the TAXII Threat Intelligence Feed APIs.",
-        "tooltip": "The Username/API Key that is configured for your account to access the TAXII Threat Intelligence Feed APIs."
+        "options": [
+          "Basic",
+          "Bearer Token",
+          "API Key Header",
+          "None"
+        ],
+        "value": "Basic",
+        "tooltip": "Authentication method used to connect to the TAXII server. Basic = username + password. Bearer Token = Authorization: Bearer <token>. API Key Header = a single named header (e.g. X-API-Key) whose value is stored as a secret. None = unauthenticated.",
+        "description": "Authentication method used to connect to the TAXII server.",
+        "onchange": {
+          "Basic": [
+            {
+              "title": "Username/API Key",
+              "name": "username",
+              "type": "text",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "description": "The Username/API Key that is configured for your account to access the TAXII Threat Intelligence Feed APIs.",
+              "tooltip": "The Username/API Key that is configured for your account to access the TAXII Threat Intelligence Feed APIs."
+            },
+            {
+              "title": "Password/API Password",
+              "name": "password",
+              "type": "password",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "value": "",
+              "description": "The Password/API Password that is configured for your account to access the TAXII Threat Intelligence Feed APIs.",
+              "tooltip": "The Password/API Password that is configured for your account to access the TAXII Threat Intelligence Feed APIs."
+            }
+          ],
+          "Bearer Token": [
+            {
+              "title": "Bearer Token",
+              "name": "bearer_token",
+              "type": "password",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "value": "",
+              "description": "Token sent as 'Authorization: Bearer <token>' on every request.",
+              "tooltip": "Token sent as 'Authorization: Bearer <token>' on every request."
+            }
+          ],
+          "API Key Header": [
+            {
+              "title": "API Key Header Name",
+              "name": "api_key_header_name",
+              "type": "text",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "placeholder": "X-API-Key",
+              "description": "Name of the HTTP header that carries the API key (e.g. X-API-Key, X-Auth-Token).",
+              "tooltip": "Name of the HTTP header that carries the API key (e.g. X-API-Key, X-Auth-Token)."
+            },
+            {
+              "title": "API Key",
+              "name": "api_key",
+              "type": "password",
+              "required": true,
+              "editable": true,
+              "visible": true,
+              "value": "",
+              "description": "Secret value sent in the API Key Header on every request.",
+              "tooltip": "Secret value sent in the API Key Header on every request."
+            }
+          ],
+          "None": []
+        }
       },
       {
-        "title": "Password/API Password",
-        "required": true,
-        "editable": true,
-        "visible": true,
-        "type": "password",
-        "name": "password",
-        "description": "The Password/API Password that is configured for your account to access the TAXII Threat Intelligence Feed APIs.",
-        "tooltip": "The Password/API Password that is configured for your account to access the TAXII Threat Intelligence Feed APIs."
-      },
-      {
-        "title": "Headers",
+        "title": "Custom Headers",
         "name": "headers",
         "visible": true,
         "required": false,
         "editable": true,
         "type": "json",
-        "tooltip": "Specify custom headers to use in the API request.",
-        "description": "Specify custom headers to use in the API request."
+        "tooltip": "Optional non-sensitive headers to attach to every request. DO NOT put secrets here — values in this field are stored and displayed in plaintext. Use the 'API Key Header' or 'Bearer Token' authentication types for secret headers.",
+        "description": "Optional non-sensitive headers to attach to every request. Values here are stored in plaintext — use 'API Key Header' or 'Bearer Token' auth for secrets."
       },
       {
         "title": "Verify SSL",

--- a/taxii2-threat-intel-feed/operations.py
+++ b/taxii2-threat-intel-feed/operations.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2025 Fortinet Inc
+Copyright (c) 2026 Fortinet Inc
 Copyright end
 """
 
@@ -36,14 +36,26 @@ class TAXIIFeed(object):
         if not self.server_url.endswith('/'):
             self.server_url += '/'
 
-        self.username = config.get('username')
-        self.password = config.get('password')
-        usr_pass = self.username + ":" + self.password
-        usr_pass = usr_pass.encode()
-        b64val = base64.b64encode(usr_pass)
-        token = 'Basic {}'.format(b64val.decode("utf-8"))
         self.custom_headers = config.get('headers') or {}
-        self.headers = {'Authorization': token}
+        auth_type = (config.get('auth_type') or 'Basic').strip()
+        auth_headers = {}
+        if auth_type == 'Basic':
+            self.username = config.get('username') or ''
+            self.password = config.get('password') or ''
+            b64val = base64.b64encode((self.username + ':' + self.password).encode())
+            auth_headers['Authorization'] = 'Basic {}'.format(b64val.decode('utf-8'))
+        elif auth_type == 'Bearer Token':
+            auth_headers['Authorization'] = 'Bearer {}'.format(config.get('bearer_token') or '')
+        elif auth_type == 'API Key Header':
+            header_name = (config.get('api_key_header_name') or '').strip()
+            if not header_name:
+                raise ConnectorError("API Key Header Name is required when Authentication Type is 'API Key Header'.")
+            auth_headers[header_name] = config.get('api_key') or ''
+        elif auth_type == 'None':
+            pass
+        else:
+            raise ConnectorError("Unsupported Authentication Type: {}".format(auth_type))
+        self.headers = {**auth_headers, **self.custom_headers}
         self.verify_ssl = config.get('verify_ssl')
         self.error_msg = {
             400: 'The parameters are invalid.',
@@ -149,8 +161,9 @@ def get_collections(config, params, **kwargs):
     taxii = TAXIIFeed(config)
     endpoint = ''
     custom_headers = params.pop('headers', '') or taxii.custom_headers
-    headers = custom_headers or {'Content-Type': 'taxii+json;version=2.1',
-                                 'Accept': 'application/taxii+json;version=2.1'}
+    headers = {'Content-Type': 'taxii+json;version=2.1',
+               'Accept': 'application/taxii+json;version=2.1',
+               **(custom_headers or {})}
     response_headers = taxii.make_request(endpoint=endpoint, headers=headers, api_info='api_root_info')
     headers = {'Accept': response_headers['Content-Type']}
     params = {k: v for k, v in params.items() if v is not None and v != ''}
@@ -170,8 +183,9 @@ def get_objects_by_collection_id(config, params, **kwargs):
     taxii = TAXIIFeed(config)
     custom_headers = params.pop('headers', '') or taxii.custom_headers
     endpoint = ''
-    headers = custom_headers or {'Content-Type': 'taxii+json;version=2.1',
-                                 'Accept': 'application/taxii+json;version=2.1'}
+    headers = {'Content-Type': 'taxii+json;version=2.1',
+               'Accept': 'application/taxii+json;version=2.1',
+               **(custom_headers or {})}
     response_headers = taxii.make_request(endpoint=endpoint, headers=headers, api_info='api_root_info')
     headers = {'Accept': response_headers['Content-Type']}
     params = get_params(params)
@@ -216,8 +230,9 @@ def get_objects(config, params, **kwargs):
     taxii = TAXIIFeed(config)
     custom_headers = params.pop('headers', '') or taxii.custom_headers
     endpoint = ''
-    headers = custom_headers or {'Content-Type': 'taxii+json;version=2.1',
-                                 'Accept': 'application/taxii+json;version=2.1'}
+    headers = {'Content-Type': 'taxii+json;version=2.1',
+               'Accept': 'application/taxii+json;version=2.1',
+               **(custom_headers or {})}
     response_headers = taxii.make_request(endpoint=endpoint, headers=headers, api_info='api_root_info')
     headers = {'Accept': response_headers['Content-Type']}
     params = get_params(params)
@@ -265,8 +280,9 @@ def download_indicators(config, params, **kwargs):
         ]
 
     # Prepare headers for TAXII requests
-    headers = custom_headers or {'Content-Type': 'taxii+json;version=2.1',
-                                 'Accept': 'application/taxii+json;version=2.1'}
+    headers = {'Content-Type': 'taxii+json;version=2.1',
+               'Accept': 'application/taxii+json;version=2.1',
+               **(custom_headers or {})}
     response_headers = taxii.make_request(endpoint=endpoint, headers=headers, api_info='api_root_info')
 
     # Extract query parameters

--- a/taxii2-threat-intel-feed/playbooks/fcp_playbooks.json
+++ b/taxii2-threat-intel-feed/playbooks/fcp_playbooks.json
@@ -7,7 +7,7 @@
       "createDate": "2025-06-10T14:25:29.834135Z",
       "modifyDate": "2025-06-10T14:25:29.873557Z",
       "deletedAt": null,
-      "name": "Sample - TAXII Threat Intel Feed - 1.2.1",
+      "name": "Sample - TAXII Threat Intel Feed - 2.0.0",
       "description": "Sample playbooks for \"TAXII Threat Intel Feed\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
       "visible": true,
       "image": null,
@@ -95,7 +95,7 @@
                   "added_after": "{{ vars.ingestion_last_pull_datetime }}",
                   "fetch_all_records": false
                 },
-                "version": "1.2.1",
+                "version": "2.0.0",
                 "connector": "taxii2-threat-intel-feed",
                 "operation": "download_indicators",
                 "pickFromTenant": false
@@ -162,7 +162,7 @@
             "createDate": "2025-06-10T14:25:29.834135Z",
             "modifyDate": "2025-06-10T14:25:29.873557Z",
             "deletedAt": null,
-            "name": "Sample - TAXII Threat Intel Feed - 1.2.1",
+            "name": "Sample - TAXII Threat Intel Feed - 2.0.0",
             "description": "Sample playbooks for \"TAXII Threat Intel Feed\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
             "visible": true,
             "image": null,

--- a/taxii2-threat-intel-feed/playbooks/playbooks.json
+++ b/taxii2-threat-intel-feed/playbooks/playbooks.json
@@ -3,7 +3,7 @@
   "data": [
     {
       "@type": "WorkflowCollection",
-      "name": "Sample - TAXII Threat Intel Feed - 1.2.1",
+      "name": "Sample - TAXII Threat Intel Feed - 2.0.0",
       "description": "Sample playbooks for \"TAXII Threat Intel Feed\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
       "visible": true,
       "image": null,
@@ -75,7 +75,7 @@
                   "collectionID": "df3d706d-aaf1-4459-a805-c961c9f9b9f2",
                   "fetch_all_records": ""
                 },
-                "version": "1.2.1",
+                "version": "2.0.0",
                 "connector": "taxii2-threat-intel-feed",
                 "operation": "get_objects_by_collection_id",
                 "operationTitle": "Fetch Indicators",
@@ -378,7 +378,7 @@
                   "collectionID": "df3d706d-aaf1-4459-a805-c961c9f9b9f2",
                   "fetch_all_records": ""
                 },
-                "version": "1.2.1",
+                "version": "2.0.0",
                 "connector": "taxii2-threat-intel-feed",
                 "operation": "get_objects",
                 "operationTitle": "Get Objects",
@@ -506,7 +506,7 @@
                 "name": "TAXII Threat Intel Feed",
                 "config": "a5a78d61-591c-4a8e-9a1d-f002313b4a14",
                 "params": [],
-                "version": "1.2.1",
+                "version": "2.0.0",
                 "connector": "taxii2-threat-intel-feed",
                 "operation": "get_collections",
                 "operationTitle": "Get Collections",
@@ -609,7 +609,7 @@
                   "create_pb_id": "36560d71-5aa0-4c35-b001-d2dc5086aac1",
                   "fetch_all_records": true
                 },
-                "version": "1.2.1",
+                "version": "2.0.0",
                 "for_each": {
                   "item": "{{vars.steps.Get_All_Collections.data.collections}}",
                   "parallel": false,
@@ -636,7 +636,7 @@
                 "name": "TAXII Threat Intel Feed",
                 "config": "a5a78d61-591c-4a8e-9a1d-f002313b4a14",
                 "params": [],
-                "version": "1.2.1",
+                "version": "2.0.0",
                 "connector": "taxii2-threat-intel-feed",
                 "operation": "get_collections",
                 "operationTitle": "Get Collections",

--- a/taxii2-threat-intel-feed/release_notes.md
+++ b/taxii2-threat-intel-feed/release_notes.md
@@ -1,12 +1,13 @@
-#### The following enhancements have been made to the TAXII Threat Intel Feed Connector in version 1.2.1:
+#### The following enhancements have been made to the TAXII Threat Intel Feed Connector in version 2.0.0:
 
-- The connector has been renamed to `TAXII Threat Intel Feed` from `TAXII2 Threat Intel Feed`.
-- Added a new action and a corresponding playbook - `Get Objects`.
-- Renamed the configuration parameter `Server URL` to `Server URL (API Root)`.
-- Under the action `Fetch Indicators`, renamed the parameter `Created After` to `Added After`.
-- Corrected field mapping for following fields during data ingestion:
-    - Pattern Type
-    - Pattern Version
-    - Source
-    - Kill Chain Phases
-- Updated the connector to support `TAXII v2.1` and `STIX v2.1` protocols.
+- Added an `Authentication Type` configuration picklist with the following options:
+    - `Basic` (existing behavior — username + password)
+    - `Bearer Token` (sent as `Authorization: Bearer <token>` on every request)
+    - `API Key Header` (configurable header name, e.g. `X-API-Key`, with a masked password-typed value)
+    - `None` (unauthenticated)
+- The `Headers` configuration field has been renamed to `Custom Headers`.
+- Connection-level custom headers are now automatically merged into every outgoing TAXII request (previously they were
+  only applied when supplied per-action).
+- Per-action `Headers` overrides now augment the default TAXII content-negotiation headers (`Content-Type`, `Accept`)
+  instead of replacing them, preventing accidental breakage of TAXII v2.1 content negotiation when a user supplies an
+  unrelated custom header.

--- a/taxii2-threat-intel-feed/tests/test_taxii.py
+++ b/taxii2-threat-intel-feed/tests/test_taxii.py
@@ -1,0 +1,92 @@
+"""
+Copyright start
+MIT License
+Copyright (c) 2026 Fortinet Inc
+Copyright end
+"""
+
+"""Tests for the TAXII Threat Intel Feed connector — focused on the v2.0.0 auth + custom-headers changes."""
+
+from base64 import b64encode
+
+import pytest
+
+
+@pytest.fixture
+def ops(load_connector):
+    return load_connector('taxii2-threat-intel-feed')
+
+
+def _config(**overrides):
+    base = {
+        'server_url': 'https://taxii.example.com/taxii/root',
+        'auth_type': 'Basic',
+        'username': 'alice',
+        'password': 'secret', #pragma: allowlist secret
+        'headers': {},
+        'verify_ssl': False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_basic_auth_header(ops):
+    client = ops.TAXIIFeed(_config())
+    assert client.headers['Authorization'].startswith('Basic ')
+    expected = 'Basic ' + b64encode(b'alice:secret').decode()
+    assert client.headers['Authorization'] == expected
+
+
+def test_bearer_auth_header(ops):
+    client = ops.TAXIIFeed(_config(auth_type='Bearer Token', bearer_token='tok-xyz',
+                                    username=None, password=None))
+    assert client.headers['Authorization'] == 'Bearer tok-xyz'
+
+
+def test_api_key_header_auth(ops):
+    client = ops.TAXIIFeed(_config(auth_type='API Key Header',
+                                    api_key_header_name='X-API-Key', api_key='abc', #pragma: allowlist secret
+                                    username=None, password=None))
+    assert client.headers['X-API-Key'] == 'abc'
+    assert 'Authorization' not in client.headers
+
+
+def test_api_key_header_requires_name(ops):
+    with pytest.raises(Exception) as exc:
+        ops.TAXIIFeed(_config(auth_type='API Key Header', api_key_header_name='', api_key='abc'))
+    assert 'API Key Header Name' in str(exc.value)
+
+
+def test_none_auth_yields_no_auth_header(ops):
+    client = ops.TAXIIFeed(_config(auth_type='None', username=None, password=None))
+    assert 'Authorization' not in client.headers
+
+
+def test_custom_headers_merged_into_self_headers(ops):
+    client = ops.TAXIIFeed(_config(
+        auth_type='Bearer Token', bearer_token='tok',
+        headers={'X-Tenant': 'acme', 'User-Agent': 'FortiSOAR'},
+        username=None, password=None,
+    ))
+    assert client.headers['X-Tenant'] == 'acme'
+    assert client.headers['User-Agent'] == 'FortiSOAR'
+    assert client.headers['Authorization'] == 'Bearer tok'
+
+
+def test_unsupported_auth_type_raises(ops):
+    with pytest.raises(Exception) as exc:
+        ops.TAXIIFeed(_config(auth_type='Magic'))
+    assert 'Unsupported Authentication Type' in str(exc.value)
+
+
+def test_make_request_attaches_auth_and_custom_headers(ops, requests_mock):
+    requests_mock.get('https://taxii.example.com/taxii/root/foo',
+                      json={'ok': True}, status_code=200)
+    client = ops.TAXIIFeed(_config(headers={'X-Tenant': 'acme'}))
+    result = client.make_request('foo', headers={'Accept': 'application/taxii+json'})
+    assert result == {'ok': True}
+    sent = requests_mock.last_request.headers
+    # Auth header from config + custom header from config + per-call header all present.
+    assert sent['Authorization'].startswith('Basic ')
+    assert sent['X-Tenant'] == 'acme'
+    assert sent['Accept'] == 'application/taxii+json'


### PR DESCRIPTION
#### Mantis: 1290644

#### Description:

- Added an `Authentication Type` configuration picklist with the following options:
    - `Basic` (existing behavior — username + password)
    - `Bearer Token` (sent as `Authorization: Bearer <token>` on every request)
    - `API Key Header` (configurable header name, e.g. `X-API-Key`, with a masked password-typed value)
    - `None` (unauthenticated)
- The `Headers` configuration field has been renamed to `Custom Headers`.
- Connection-level custom headers are now automatically merged into every outgoing TAXII request (previously they were
  only applied when supplied per-action).
- Per-action `Headers` overrides now augment the default TAXII content-negotiation headers (`Content-Type`, `Accept`)
  instead of replacing them, preventing accidental breakage of TAXII v2.1 content negotiation when a user supplies an
  unrelated custom header.

#### UTCs:

- [x] Not having setup in our lab, not able to verify the connector.